### PR TITLE
Pushing reusable flow to master so it can be reused

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,9 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Debug
-        run: ls -lR
+        run: |
+          pwd
+          ls -laR
       - name: Validate composer.json and composer.lock
         uses: ./.github/workflows/setup-composer.yml
         

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,20 +14,8 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Validate composer.json and composer.lock
-        run: composer validate --strict
+        uses: ./.github/workflows/setup-composer.yml
         
-      - name: Cache Composer packages
-        id: composer-cache
-        uses: actions/cache@v2
-        with:
-          path: vendor
-          key: ${{ runner.os }}-php-${{ hashFiles('**/composer.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-php-      - name: Install composer dependencies
-      
-      - name: Install composer dependencies
-        run: composer install --prefer-dist
-
       - name: Run unit tests
         run: |
           composer test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,8 +15,7 @@ jobs:
 
       - name: Debug
         run: |
-          pwd
-          ls -laR
+          ls -la /home/runner/work/f3rva-api/f3rva-api/.github/workflows/setup-composer.yml
       - name: Validate composer.json and composer.lock
         uses: ./.github/workflows/setup-composer.yml
         

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,8 @@ jobs:
       - name: Checkout from repo
         uses: actions/checkout@v2
 
+      - name: Debug
+        run: ls -lR
       - name: Validate composer.json and composer.lock
         uses: ./.github/workflows/setup-composer.yml
         

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,11 +13,22 @@ jobs:
       - name: Checkout from repo
         uses: actions/checkout@v2
 
-      - name: Debug
-        run: |
-          ls -la /home/runner/work/f3rva-api/f3rva-api/.github/workflows/setup-composer.yml
+#      - name: Validate composer.json and composer.lock
+#        uses: ./.github/workflows/setup-composer.yml
       - name: Validate composer.json and composer.lock
-        uses: ./.github/workflows/setup-composer.yml
+        run: composer validate --strict
+        
+      - name: Cache Composer packages
+        id: composer-cache
+        uses: actions/cache@v2
+        with:
+          path: vendor
+          key: ${{ runner.os }}-php-${{ hashFiles('**/composer.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-php-      - name: Install composer dependencies
+      
+      - name: Install composer dependencies
+        run: composer install --prefer-dist
         
       - name: Run unit tests
         run: |

--- a/.github/workflows/setup-composer.yml
+++ b/.github/workflows/setup-composer.yml
@@ -1,0 +1,26 @@
+name: Setup Composer
+
+on: 
+  workflow_call:
+
+jobs:
+
+  # validate and install composer
+  setup-composer:
+    name: Validate and install composer dependencies
+    runs-on: ubuntu-latest
+    steps:
+      - name: Validate composer.json and composer.lock
+        run: composer validate --strict
+        
+      - name: Cache Composer packages
+        id: composer-cache
+        uses: actions/cache@v2
+        with:
+          path: vendor
+          key: ${{ runner.os }}-php-${{ hashFiles('**/composer.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-php-      - name: Install composer dependencies
+      
+      - name: Install composer dependencies
+        run: composer install --prefer-dist

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -13,8 +13,8 @@
 			<directory>./src</directory>
 		</include>
 		<report>
-			<html outputDirectory="./test-output/coverage" lowUpperBound="60" highLowerBound="90" showUncoveredFiles="true"/>
-			<text outputFile="php://stdout" lowUpperBound="60" highLowerBound="90" showUncoveredFiles="true"/>
+			<html outputDirectory="./test-output/coverage" lowUpperBound="60" highLowerBound="90" />
+			<text outputFile="php://stdout" showUncoveredFiles="true"/>
 		</report>
 	</coverage>
 	<logging>


### PR DESCRIPTION
Subflow needs to be in master in order for it to be called from parent workflows.  We could explicitly declare that we are referencing a branch, but that has significant security implications.